### PR TITLE
Add Whisfusion to Diffusion-LLM-Papers (Multimodal > Speech/ASR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Since our time is limited and we can't cover everything, **please feel free to s
 **MMaDA: Multimodal Large Diffusion Language Models**  
 2025-5-21, [Paper](https://arxiv.org/abs/2505.15809)
 
+### Speech / ASR
+**Whisfusion: Parallel ASR Decoding via a Diffusion Transformer**  
+2025-8-9, [Paper](https://arxiv.org/abs/2508.07048)
 
 ## Fast Sampling
 ### Enable KV Cache


### PR DESCRIPTION
This PR adds Whisfusion: Parallel ASR Decoding via a Diffusion Transformer.

- Category: Multimodal Model → Speech / ASR
- Date: 2025-08-09 (arXiv submission)
- Paper: https://arxiv.org/abs/2508.07048

Rationale: Whisfusion fuses a Whisper encoder with a diffusion decoder (SMDM) to enable non-autoregressive, parallel decoding for speech (audio→text).